### PR TITLE
Use node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: ${{ github.token }}
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'cancel.js'
 branding:
   icon: 'cloud-snow'


### PR DESCRIPTION
First of all, thank you for the action, i love the functionality!

Github is bumping all actions to node 16 since node 12 was EOL in April, ref: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Bumping this to node 16.